### PR TITLE
Add 'npm install' to Getting Started - Installation Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You can start editing the page by modifying `pages/index.js`. The page auto-upda
 **Option two:** Manual clone
 
 1. Clone this repo: `git clone https://github.com/cassidoo/next-netlify-starter.git`
-2. Navigate to the directory and run `npm run dev`
-3. Make your changes
-4. Connect to [Netlify](https://url.netlify.com/Bk4UicocL) manually (the `netlify.toml` file is the one you'll need to make sure stays intact to make sure the export is done and pointed to the right stuff)
+2. Navigate to the directory and run `npm install`
+3. Run `npm run dev`
+4. Make your changes
+5. Connect to [Netlify](https://url.netlify.com/Bk4UicocL) manually (the `netlify.toml` file is the one you'll need to make sure stays intact to make sure the export is done and pointed to the right stuff)


### PR DESCRIPTION
This just adds `npm install` to the getting started instructions. 

I opened an issue as well that this addresses, but I'm still new to pull requests and haven't figured out how to link it yet. 

